### PR TITLE
Install updates very silently

### DIFF
--- a/elevenclock/__init__.py
+++ b/elevenclock/__init__.py
@@ -401,7 +401,7 @@ def updateIfPossible():
             if(hashlib.sha256(datatowrite).hexdigest().lower() == response.split("///")[2].replace("\n", "").lower()):
                 print("Hash: ", response.split("///")[2].replace("\n", "").lower())
                 print("Hash ok, starting update")
-                subprocess.run('start /B "" "{0}" /silent'.format(filename), shell=True)
+                subprocess.run('start /B "" "{0}" /verysilent'.format(filename), shell=True)
             else:
                 print("Hash not ok")
                 print("File hash: ", hashlib.sha256(datatowrite).hexdigest())


### PR DESCRIPTION
Avoids taking over the user's focus when running the installer

The `/silent` argument still displays a progress window, making the user lose the focus on the active software/game
The `/verysilent` still takes the user's focus, but for a much shorter duration and gives it back to the focused app