### PR TITLE
Fix issue #649

### DIFF
--- a/elevenclock/__init__.py
+++ b/elevenclock/__init__.py
@@ -403,11 +403,14 @@ try:
     def timeStrThread():
         global timeStr, dateTimeFormat
         fixHyphen = getSettings("EnableHyphenFix")
+        encoding = 'unicode-escape'
         adverted = False
         while True:
             for _ in range(36000):
                 try:
-                    timeStr = datetime.datetime.now().strftime(dateTimeFormat)
+                    dateTimeFormatUnicode = dateTimeFormat.encode(encoding).decode()
+                    now = datetime.datetime.now()
+                    timeStr = now.strftime(dateTimeFormatUnicode).encode().decode(encoding)
                     adverted = False
                     if fixHyphen:
                         timeStr = timeStr.replace("t-", "t -")


### PR DESCRIPTION
It should be "datetime.strftime()" issue that cannot handle unicode strings, such as " " (U+200A: Hair space).
I would like to revert changes to https://github.com/martinet101/ElevenClock/commit/c8b5f27fb9d1d14fdd0a1e74ce9ac2957e6cc7de