### PR TITLE
Change Python to v3.10

### DIFF
--- a/.github/workflows/Basic health check.yml
+++ b/.github/workflows/Basic health check.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Installing dependencies
       run: |
         python -m pip install --upgrade pip

--- a/elevenclock/settings.py
+++ b/elevenclock/settings.py
@@ -450,7 +450,7 @@ class SettingsWindow(QMainWindow):
                 <p>{_("ElevenClock is an Open-Source application made with the help of other libraries made by the community:")}</p><br>
                 <style> a {{color: rgb({colors[2 if isWindowDark() else 4]})}}</style>
                 <ul>
-                <li> <b>Python 3.9</b>: <a href="https://docs.python.org/3/license.html">PSF License Agreement</a></li>
+                <li> <b>Python 3.10</b>: <a href="https://docs.python.org/3/license.html">PSF License Agreement</a></li>
                 <li> <b>Win32mica</b> (Also made by me): <a href="https://github.com/martinet101/pymica/blob/master/LICENSE">MIT License</a></li>
                 <li> <b>PyAutoGui</b>: <a href="https://github.com/asweigart/pyautogui/">BSD-3 Clause New</a></li>
                 <li> <b>PyWin32</b>: <a href="https://pypi.org/project/pywin32/">PSF-2.0</a></li>


### PR DESCRIPTION
[Changelog](https://github.com/martinet101/ElevenClock/releases/tag/3.4.0) says about upgrade python to v3.10, but is not real that all.

[Wiki](https://github.com/martinet101/ElevenClock/wiki#installing-dependencies) modified too.