### PR TITLE
Remove install dateutil via easy_install

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,5 @@
 python -m pip install -r requirements.txt
 python -m pip install setuptools==49.1.3
-python -m pip uninstall python-dateutil -y
-python -m easy_install python-dateutil
 xcopy elevenclock elevenclock_bin  /E /H /C /I 
 cd elevenclock_bin
 python -m compileall -b .

--- a/requirements_install.bat
+++ b/requirements_install.bat
@@ -1,5 +1,3 @@
 python -m pip install -r requirements.txt
 python -m pip install setuptools==49.1.3
-python -m pip uninstall python-dateutil -y
-python -m easy_install python-dateutil
 pause


### PR DESCRIPTION
I think, that is not necessary: https://github.com/martinet101/ElevenClock/commit/3137aaf1c0cae81067b03f3ca04634329c97ec1e#r75552375