### PR TITLE
Fix detecting fullscreen of NVIDIA Overlay

### DIFF
--- a/elevenclock/__init__.py
+++ b/elevenclock/__init__.py
@@ -58,7 +58,7 @@ try:
     from external.WnfReader import isFocusAssistEnabled, getNotificationNumber
 
     blacklistedProcesses = ["msrdc.exe", "mstsc.exe", "CDViewer.exe", "wfica32.exe", "vmware-view.exe", "vmware.exe"]
-    blacklistedFullscreenApps = ("", "Program Manager", "NVIDIA GeForce Overlay", "ElenenClock_IgnoreFullscreenEvent") # The "" codes for titleless windows
+    blacklistedFullscreenApps = ("", "Program Manager", "NVIDIA GeForce Overlay", "NVIDIA GeForce Overlay DT", "ElenenClock_IgnoreFullscreenEvent") # The "" codes for titleless windows
 
     seconddoubleclick = False
     isRDPRunning = False


### PR DESCRIPTION
Recently NVIDIA Geforce Overlay changed its window name to NVIDIA GeForce Overlay DT. So ElevenClock will behave like #376. This PR adds the new window name into blacklisted apps.