### PR TITLE
fix hi-dpi fullscreen detection, fix netflix playback issue

### DIFF
--- a/elevenclock/__init__.py
+++ b/elevenclock/__init__.py
@@ -1264,11 +1264,12 @@ try:
                 fullscreen = False
 
                 def compareFullScreenRects(window, screen, ADVANCED_FULLSCREEN_METHOD):
+                    screenInPixel = [self.get6px(screen[0]), self.get6px(screen[1]), self.get6px(screen[2]), self.get6px(screen[3])]
                     try:
                         if(ADVANCED_FULLSCREEN_METHOD):
-                            return  window[0] <= screen[0] and window[1] <= screen[1] and window[2] >= screen[2] and window[3] >= screen[3] and window[0]+8 != screen[0] and window[1]+8 != screen[1]
+                            return  window[0] <= screenInPixel[0] and window[1] <= screenInPixel[1] and window[2] >= screenInPixel[2] and window[3] >= screenInPixel[3] and window[0]+8 != screenInPixel[0] and window[1]+8 != screenInPixel[1]
                         else:
-                            return  window[0] == screen[0] and window[1] == screen[1] and window[2] == screen[2] and window[3] == screen[3]
+                            return  window[0] == screenInPixel[0] and window[1] == screenInPixel[1] and window[2] == screenInPixel[2] and window[3] == screenInPixel[3]
                     except Exception as e:
                         report(e)
 
@@ -1286,7 +1287,7 @@ try:
                                     for p in processes:
                                         if p.Name != "TextInputHost.exe":
                                             if(win32gui.GetWindowText(hwnd) not in blacklistedFullscreenApps):
-                                                print("🟡 Fullscreen window detected!", win32gui.GetWindowRect(hwnd), "Fullscreen rect:", self.fullScreenRect)
+                                                print("🟡 Fullscreen window detected!", win32gui.GetWindowRect(hwnd), "Fullscreen rect:", self.fullScreenRect, f"with {self.screen().devicePixelRatio()}x scaling")
                                                 if LOG_FULLSCREEN_WINDOW_TITLE:
                                                     print("🟡 Fullscreen window title:", win32gui.GetWindowText(hwnd))
                                                 fullscreen = True
@@ -1296,7 +1297,7 @@ try:
                                             self.INTLOOPTIME = 2
                             else:
                                 if win32gui.GetWindowText(hwnd) not in blacklistedFullscreenApps and hwnd != self.textInputHostHWND:
-                                    print("🟡 Fullscreen window detected!", win32gui.GetWindowRect(hwnd), "Fullscreen rect:", self.fullScreenRect)
+                                    print("🟡 Fullscreen window detected!", win32gui.GetWindowRect(hwnd), "Fullscreen rect:", self.fullScreenRect, f"with {self.screen().devicePixelRatio()}x scaling")
                                     if LOG_FULLSCREEN_WINDOW_TITLE:
                                         print("🟡 Fullscreen window title:", win32gui.GetWindowText(hwnd))
                                     fullscreen = True
@@ -1306,7 +1307,7 @@ try:
                     hwnd = win32gui.GetForegroundWindow()
                     if(compareFullScreenRects(win32gui.GetWindowRect(hwnd), self.fullScreenRect, ADVANCED_FULLSCREEN_METHOD)):
                         if(win32gui.GetWindowText(hwnd) not in blacklistedFullscreenApps):
-                            print("🟡 Fullscreen window detected!", win32gui.GetWindowRect(hwnd), "Fullscreen rect:", self.fullScreenRect)
+                            print("🟡 Fullscreen window detected!", win32gui.GetWindowRect(hwnd), "Fullscreen rect:", self.fullScreenRect, f"with {self.screen().devicePixelRatio()}x scaling")
                             if LOG_FULLSCREEN_WINDOW_TITLE:
                                 print("🟡 Fullscreen window title:", win32gui.GetWindowText(hwnd))
                             fullscreen = True

--- a/elevenclock/__init__.py
+++ b/elevenclock/__init__.py
@@ -1335,9 +1335,11 @@ try:
                 self.INTLOOPTIME = 15
             else:
                 self.INTLOOPTIME = 2
+            loopCount = 0
             while True:
                 self.isRDPRunning = isRDPRunning
                 isFullScreen = self.theresFullScreenWin(CLOCK_ON_FIRST_MONITOR, ADVANCED_FULLSCREEN_METHOD, LEGACY_FULLSCREEN_METHOD, LOG_FULLSCREEN_WINDOW_TITLE)
+                hideClock = False
                 for i in range(self.INTLOOPTIME):
                     if (not(isFullScreen) or not(ENABLE_HIDE_ON_FULLSCREEN)) and not self.clockShouldBeHidden:
                         if SHOW_NOTIFICATIONS:
@@ -1366,15 +1368,19 @@ try:
                                         self.refresh.emit()
                                     else:
                                         self.hideSignal.emit()
+                                        hideClock = True
                                 else:
                                     self.hideSignal.emit()
+                                    hideClock = True
                         else:
                             if(self.isRDPRunning and ENABLE_HIDE_FROM_RDP):
                                 self.hideSignal.emit()
+                                hideClock = True
                             else:
                                 self.refresh.emit()
                     else:
                         self.hideSignal.emit()
+                        hideClock = True
                     if not ENABLE_HIDE_ON_FULLSCREEN:
                         if isFullScreen:
                             self.tempMakeClockTransparent = MAKE_CLOCK_TRANSPARENT_WHEN_FULLSCREENED
@@ -1383,7 +1389,14 @@ try:
                     else:
                         self.tempMakeClockTransparent = False
                     time.sleep(0.2)
-                self.checkAndUpdateBackground()
+                if not hideClock:
+                    if loopCount >= 2:
+                        self.checkAndUpdateBackground()
+                        loopCount = 0
+                    else:
+                        loopCount += 1
+                else:
+                    loopCount = 0
                 time.sleep(0.2)
 
         def updateTextLoop(self) -> None:


### PR DESCRIPTION
This PR contains two patches: fix hi-dpi fullscreen detection, fix netflix playback issue

Patch 1:
It seems QT6 screen.geometry will return scaled screen size, not in pixel, while win32gui.GetWindowRect will return screen size in pixel. This inconsistency will lead to wrong detection of fullscreen windows (e.g., a maximized vscode window in 150% DPI scale). This patch fixes it by converting win32gui.GetWindowRect size to pixel size by using get6px function.

Patch 2: (fixes #622)
This patch changes the backgroundLoop thread to a subroutine of the mainClockLoop thread. For now, background detection is always performed after fullscreen detection, which solves the Netflix UWP application timing issue. This may need further testing, but it works on my PC without issues. The next commit further adjusts the timing of background detection to 0.4-0.6 second. By testing on my PC, setting to those values achieves a balance between the delay of background change and the playback issue with Netflix. Note that Netflix will still blinks rarely, but then plays normally without issue. I consider the blinking phonomenon is occurred at the exact time ElevenClock capturing the screen for background detection, and I think it cannot be easily solved. Anyway, Netflix is totally usable with ElevenClock on.

**Please note that Netflix only works on enabling 'Check only the focused window on the fullscreen check'**, or LEGACY_FULLSCREEN_METHOD, in experimental features. By debugging, it seems that the new fullscreen method cannot enum the fullscreen Netflix player window, but can get the regular Netflix UWP application window though, maybe due to some kind of protection.

Maybe you can add some additional explanation (e.g., fixes Netflix) to that option?