### PR TITLE
Check response code after download translations

### DIFF
--- a/elevenclock/lang/download_translations.py
+++ b/elevenclock/lang/download_translations.py
@@ -41,9 +41,15 @@ print()
 print("  Downloading updated translations...")
 
 
-zipcontent = requests.get(apiurl)
+response = requests.get(apiurl)
+if (not response.ok):
+    statusCode = response.status_code
+    print(f"  Error {statusCode}: {response.text}")
+    if (statusCode == 403):
+        print(f"  APIKEY is probably wrong!")
+    exit(1)
 f = open("langs.zip", "wb")
-f.write(zipcontent.content)
+f.write(response.content)
 langArchiveName = f.name
 f.close()
 


### PR DESCRIPTION
Actually "Retrieve latest translations from Tolgee" fails, probably your apikey is expired.

> https://github.com/martinet101/ElevenClock/actions/workflows/lang-updates.yml