### PR TITLE
Update Winget Releaser workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/winget-release.yml
+++ b/.github/workflows/winget-release.yml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: windows-latest # action can only be run on windows
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@latest
+      - uses: vedantmgoyal2009/winget-releaser@v1
         with:
           identifier: SomePythonThings.ElevenClock
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Winget Releaser is now switching to version tags instead of the `latest` tag.