### PR TITLE
Fix netflix and refine loadWindowsInfo thread

### DIFF
--- a/elevenclock/__init__.py
+++ b/elevenclock/__init__.py
@@ -286,7 +286,6 @@ try:
         global isFocusAssist, numOfNotifs
         while True:
             isFocusAssist = isFocusAssistEnabled()
-            time.sleep(0.3)
             numOfNotifs = getNotificationNumber()
             time.sleep(0.3)
 
@@ -321,6 +320,7 @@ try:
         loadClocks()
         loadTimeFormat()
         setSettings("ReloadInternetTime", True, thread=True)
+        globals.doCacheHost = True
 
         try:
             rdpThread.kill()
@@ -649,7 +649,6 @@ try:
         shouldBeVisible = True
         isRDPRunning = True
         clockOnTheLeft = False
-        textInputHostHWND = 0
         INTLOOPTIME = 2
         tempMakeClockTransparent = False
         clockCover = None
@@ -1291,27 +1290,10 @@ try:
                 
                 if not LEGACY_FULLSCREEN_METHOD:
                     for hwnd in globals.windowList:
-                        if globals.windowVisible[hwnd]:
-                            if compareFullScreenRects(globals.windowRects[hwnd], self.fullScreenRect, ADVANCED_FULLSCREEN_METHOD):
-                                if CLOCK_ON_FIRST_MONITOR and self.textInputHostHWND == 0:
-                                        pythoncom.CoInitialize()
-                                        _, pid = win32process.GetWindowThreadProcessId(hwnd)
-                                        _wmi = win32com.client.GetObject('winmgmts:')
-
-                                        # collect all the running processes
-                                        processes = _wmi.ExecQuery(f'Select Name from win32_process where ProcessId = {pid}')
-                                        for p in processes:
-                                            if p.Name != "TextInputHost.exe":
-                                                if(globals.windowTexts[hwnd] not in blacklistedFullscreenApps):
-                                                    print("🟡 Fullscreen window detected!", globals.windowRects[hwnd], "Fullscreen rect:", screenGeometryToPixel(self.fullScreenRect))
-                                                    if LOG_FULLSCREEN_WINDOW_TITLE:
-                                                        print("🟡 Fullscreen window title:", globals.windowTexts[hwnd])
-                                                    fullscreen = True
-                                            else:
-                                                print("🟢 Cached text input host hwnd:", hwnd)
-                                                self.textInputHostHWND = hwnd
-                                else:
-                                    if globals.windowTexts[hwnd] not in blacklistedFullscreenApps and hwnd != self.textInputHostHWND:
+                        if hwnd in globals.windowVisible.keys():
+                            if globals.windowVisible[hwnd]:
+                                if compareFullScreenRects(globals.windowRects[hwnd], self.fullScreenRect, ADVANCED_FULLSCREEN_METHOD):                                            
+                                    if globals.windowTexts[hwnd] not in blacklistedFullscreenApps:
                                         print("🟡 Fullscreen window detected!", globals.windowRects[hwnd], "Fullscreen rect:", screenGeometryToPixel(self.fullScreenRect))
                                         if LOG_FULLSCREEN_WINDOW_TITLE:
                                             print("🟡 Fullscreen window title:", globals.windowTexts[hwnd])
@@ -1370,7 +1352,7 @@ try:
             if self.IS_LOW_CPU_MODE:
                 self.WAITLOOPTIME = 0.8
             else:
-                self.WAITLOOPTIME = 0.2
+                self.WAITLOOPTIME = 0.1
             loopCount = 0
             while True:
                 self.isRDPRunning = isRDPRunning

--- a/elevenclock/globals.py
+++ b/elevenclock/globals.py
@@ -52,4 +52,5 @@ windowVisible: dict[int, bool] = {}
 windowList: list[int] = []
 newWindowList: list[int] = []
 foregroundHwnd: int = 0
+doCacheHost: bool = False
 previousFullscreenHwnd: dict[int, int] = {}

--- a/elevenclock/globals.py
+++ b/elevenclock/globals.py
@@ -52,3 +52,4 @@ windowVisible: dict[int, bool] = {}
 windowList: list[int] = []
 newWindowList: list[int] = []
 foregroundHwnd: int = 0
+previousFullscreenHwnd: dict[int, int] = {}

--- a/elevenclock/tools.py
+++ b/elevenclock/tools.py
@@ -29,6 +29,8 @@ from urllib.request import urlopen
 
 from win32con import *
 
+import pywintypes
+
 
 try:
     winver = int(platform.version().split('.')[2])
@@ -737,8 +739,22 @@ def appendWindowList(hwnd, _):
 def loadWindowsInfoThread():
     while True:
         globals.newWindowList = []
+        globals.windowTexts = {}
+        globals.windowRects = {}
+        globals.windowVisible = {}
         globals.foregroundHwnd = win32gui.GetForegroundWindow()
         win32gui.EnumWindows(appendWindowList, 0)
+        if globals.foregroundHwnd not in globals.newWindowList:
+            try:
+                appendWindowList(globals.foregroundHwnd, _)
+            except pywintypes.error:
+                pass
+        for i, previousFullscreenHwnd in globals.previousFullscreenHwnd.items():
+            if previousFullscreenHwnd != 0 and previousFullscreenHwnd not in globals.newWindowList:
+                try:
+                    appendWindowList(previousFullscreenHwnd, _)
+                except pywintypes.error:
+                    globals.previousFullscreenHwnd[i] = 0
         globals.windowList = globals.newWindowList
         time.sleep(0.8 if getSettings("EnableLowCpuMode") else 0.2)
 

--- a/elevenclock/versions.py
+++ b/elevenclock/versions.py
@@ -1,2 +1,2 @@
-version = 3.91
-versionName = "3.9.1"
+version = 3.919
+versionName = "3.9.2-beta"


### PR DESCRIPTION
This pr fixes Netflix UWP App support which was broken since 3.9.0 and refine loadWindowsInfo thread.

Since the new windows detection approach cannot detect Netflix fullscreen window, users must use the legacy mode to make Netflix work which uses win32gui.GetForegroundWindow. However, the window rect is not added to the lists. This make the legacy mode unable to detect windows. This pr fixes it.

The loadWindowsInfo thread enumerates windows every 0.2s, but does not clear the window rects and other infomations stored in dict. This may lead to potential memory leak. This pr clears the dicts every iteration.

Note that Netflix is working properly even not using legacy mode for now. This is because in loadWindowsInfo thread, the new and legacy approaches are both performed. But since the new approach cannot detect Netflix fullscreen window, if Netflix loses focus (e.g., click on the another monitor), the screen will goes black because the foreground window changed and cannot be queried. However, the legacy mode has some adaptation on this, as it will store the previous fullscreen window for each screen. **So, it is still recommended for users to enable the legacy mode to deal with Netflix.**, though the basic function is usable when the legacy mode is not enabled.